### PR TITLE
Make sign up button more obvious

### DIFF
--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -297,21 +297,21 @@ a:focus {
 .btn {
     text-transform: uppercase;
     font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-weight: 400;
+    font-weight: bold;
     -webkit-transition: all .3s ease-in-out;
     -moz-transition: all .3s ease-in-out;
     transition: all .3s ease-in-out;
 }
 
 .btn-default {
-    border: 1px solid #95d074;
+    border: 5px solid #95d074;
     color: #95d074;
     background-color: transparent;
 }
 
 .btn-default:hover,
 .btn-default:focus {
-    border: 1px solid #95d074;
+    border-color: #95d074;
     outline: 0;
     color: #000;
     background-color: #95d074;


### PR DESCRIPTION
Someone I sent the link to asked how they sign up, and I think because the button is hard to notice if you don't know it's there. This makes its slightly bolder.

Before:

![before](http://f.cl.ly/items/2a0j3Z292r1D0J0r0T3D/Screen%20Shot%202015-02-18%20at%207.46.05%20PM.png)

After:

![after](http://f.cl.ly/items/0b3w0c0w2Z3y3C0B0m2x/Screen%20Shot%202015-02-18%20at%207.49.42%20PM.png)

Alternatively, the button behaviour could be reversed so that normally it is solid color, and transparent when hovered.
